### PR TITLE
Add black formatter to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,11 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings~=1.6.0
+
+  - repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+      - id: black
+        language_version: 3.10.5
+        args:
+          - --line-length=100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,6 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black
-        language_version: 3.10.5
+        language_version: "3.10"
         args:
           - --line-length=100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,4 +36,4 @@ repos:
       - id: black
         language_version: "3.10"
         args:
-          - --line-length=100
+          - --line-length=119


### PR DESCRIPTION
Currently set the line length to 100. I feel 88 (default) can sometimes wrap code in an odd way and 100 is just a nice round number. Open to changes.