### PR TITLE
Add pep8-naming

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,4 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings~=1.6.0
+          - pep8-naming~=0.13.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,3 +9,4 @@ pre-commit~=2.17.0
 
 # Flake8 plugins, see https://github.com/python-discord/code-jam-template/tree/main#plugin-list
 flake8-docstrings~=1.6.0
+pep8-naming~=0.13.1


### PR DESCRIPTION
This adds the pep8-naming package to the dev requirements and to the pre-commit configuration.